### PR TITLE
Fix crash when article has no link

### DIFF
--- a/Today/Models/Article.swift
+++ b/Today/Models/Article.swift
@@ -60,6 +60,12 @@ final class Article {
         self.feed = feed
     }
 
+    /// The article's link as a URL, or nil if the link is empty or invalid
+    var articleURL: URL? {
+        guard !link.isEmpty else { return nil }
+        return URL(string: link)
+    }
+
     /// Returns true if the article has minimal content (short summary only)
     /// These articles should open directly in web view for full content
     var hasMinimalContent: Bool {

--- a/Today/Views/ArticleDetailSimple.swift
+++ b/Today/Views/ArticleDetailSimple.swift
@@ -74,7 +74,7 @@ struct ArticleDetailSimple: View {
 
                 // For short articles with "Open in Today Browser", show full web page
                 if article.hasMinimalContent && shortArticleBehavior == .openInAppBrowser && !article.isRedditPost,
-                   let url = URL(string: article.link) {
+                   let url = article.articleURL {
                     WebViewRepresentable(url: url)
                         .frame(height: geometry.size.height - 200)
                 }
@@ -108,9 +108,11 @@ struct ArticleDetailSimple: View {
                     .foregroundStyle(Color.accentColor)
                     .accessibilityLabel(isPlayingThisArticle ? "Pause article audio" : "Play article audio")
 
-                    // Share button
-                    ShareLink(item: URL(string: article.link)!, subject: Text(article.title)) {
-                        Image(systemName: "square.and.arrow.up")
+                    // Share button (only show if article has a valid link)
+                    if let url = article.articleURL {
+                        ShareLink(item: url, subject: Text(article.title)) {
+                            Image(systemName: "square.and.arrow.up")
+                        }
                     }
                 }
             }
@@ -142,31 +144,31 @@ struct ArticleDetailSimple: View {
                         }
                     }
 
-                    // Read in App button with long-press menu
-                    NavigationLink {
-                        ArticleWebViewSimple(url: URL(string: article.link)!)
-                    } label: {
-                        Label("Read in App", systemImage: "doc.text")
-                    }
-                    .contextMenu {
-                        Button {
-                            if let url = URL(string: article.link) {
+                    // Read in App button with long-press menu (only show if article has a valid link)
+                    if let url = article.articleURL {
+                        NavigationLink {
+                            ArticleWebViewSimple(url: url)
+                        } label: {
+                            Label("Read in App", systemImage: "doc.text")
+                        }
+                        .contextMenu {
+                            Button {
                                 openURL(url)
+                            } label: {
+                                Label("Open in Safari", systemImage: "safari")
                             }
-                        } label: {
-                            Label("Open in Safari", systemImage: "safari")
-                        }
 
-                        ShareLink(item: URL(string: article.link)!, subject: Text(article.title)) {
-                            Label("Share", systemImage: "square.and.arrow.up")
-                        }
+                            ShareLink(item: url, subject: Text(article.title)) {
+                                Label("Share", systemImage: "square.and.arrow.up")
+                            }
 
-                        Divider()
+                            Divider()
 
-                        Button {
-                            markAsUnreadAndGoBack()
-                        } label: {
-                            Label("Mark as Unread", systemImage: "envelope.badge")
+                            Button {
+                                markAsUnreadAndGoBack()
+                            } label: {
+                                Label("Mark as Unread", systemImage: "envelope.badge")
+                            }
                         }
                     }
 

--- a/Today/Views/ArticleWebView.swift
+++ b/Today/Views/ArticleWebView.swift
@@ -82,7 +82,7 @@ struct ArticleDetailViewEnhanced: View {
     var body: some View {
         ZStack {
             if showSafariView {
-                if let url = URL(string: article.link) {
+                if let url = article.articleURL {
                     // Use SafariView for full WebAuthn/passkey support
                     SafariView(url: url)
                         .ignoresSafeArea()
@@ -130,7 +130,7 @@ struct ArticleDetailViewEnhanced: View {
                             .buttonStyle(.plain)
 
                             Button {
-                                if let url = URL(string: article.link) {
+                                if let url = article.articleURL {
                                     openURL(url)
                                 }
                             } label: {

--- a/Today/Views/RedditPostView.swift
+++ b/Today/Views/RedditPostView.swift
@@ -108,7 +108,7 @@ struct RedditPostView: View {
                     Image(systemName: "square.and.arrow.up")
                 }
                 .contextMenu {
-                    if let url = URL(string: article.link) {
+                    if let url = article.articleURL {
                         ShareLink(item: url, subject: Text(article.title)) {
                             Label("Share", systemImage: "square.and.arrow.up")
                         }
@@ -130,26 +130,26 @@ struct RedditPostView: View {
 
                     // Open in Safari button
                     Button {
-                        if let url = URL(string: article.link) {
+                        if let url = article.articleURL {
                             openURL(url)
                         }
                     } label: {
                         Label("Safari", systemImage: "safari")
                     }
                     .contextMenu {
-                        Button {
-                            if let url = URL(string: article.link) {
+                        if let url = article.articleURL {
+                            Button {
                                 openURL(url)
+                            } label: {
+                                Label("Open in Safari", systemImage: "safari")
                             }
-                        } label: {
-                            Label("Open in Safari", systemImage: "safari")
-                        }
 
-                        ShareLink(item: URL(string: article.link)!, subject: Text(article.title)) {
-                            Label("Share", systemImage: "square.and.arrow.up")
-                        }
+                            ShareLink(item: url, subject: Text(article.title)) {
+                                Label("Share", systemImage: "square.and.arrow.up")
+                            }
 
-                        Divider()
+                            Divider()
+                        }
 
                         Button {
                             markAsUnreadAndGoBack()

--- a/Today/Views/TodayView.swift
+++ b/Today/Views/TodayView.swift
@@ -274,7 +274,7 @@ struct TodayView: View {
                                     switch shortArticleBehavior {
                                     case .openInBrowser:
                                         // Open in default browser (Safari)
-                                        if let url = URL(string: article.link) {
+                                        if let url = article.articleURL {
                                             openURL(url)
                                             article.isRead = true
                                             try? modelContext.save()
@@ -762,7 +762,7 @@ struct ArticleDetailView: View {
                 }
 
                 Button {
-                    if let url = URL(string: article.link) {
+                    if let url = article.articleURL {
                         openURL(url)
                     }
                 } label: {


### PR DESCRIPTION
## Summary
- Fix fatal crash when viewing articles from RSS feeds without `<link>` elements (e.g., status page feeds)
- Add `articleURL` computed property to safely handle empty/invalid links
- Conditionally show Share and "Read in App" buttons only when URL is valid

## Test plan
- [ ] Subscribe to WordPress VIP Status feed: `https://wpvipstatus.com/rss`
- [ ] Open any article from the feed
- [ ] Verify app doesn't crash
- [ ] Verify Share button is hidden (no link available)
- [ ] Verify "Read in App" button is hidden (no link available)

## Credit
Bug reported by [@GaryJones](https://github.com/GaryJones)

🤖 Generated with [Claude Code](https://claude.com/claude-code)