### PR TITLE
Add train-car article paging with preloading

### DIFF
--- a/Today/Services/RedditPostCache.swift
+++ b/Today/Services/RedditPostCache.swift
@@ -1,0 +1,68 @@
+import Foundation
+import SwiftData
+
+/// Caches preloaded Reddit post data for smooth train-car paging.
+/// Used by ArticlePagerView to prefetch adjacent Reddit posts.
+@MainActor
+class RedditPostCache {
+    static let shared = RedditPostCache()
+
+    struct CachedPost {
+        let post: ParsedRedditPost
+        let comments: [RedditComment]
+    }
+
+    private var cache: [PersistentIdentifier: CachedPost] = [:]
+    private var inFlightTasks: [PersistentIdentifier: Task<Void, Never>] = [:]
+
+    private init() {}
+
+    /// Get cached data for an article, if available.
+    func get(for articleID: PersistentIdentifier) -> CachedPost? {
+        cache[articleID]
+    }
+
+    /// Preload Reddit post data for an article. No-op if already cached or in flight.
+    func preload(article: Article) {
+        let articleID = article.persistentModelID
+        guard cache[articleID] == nil, inFlightTasks[articleID] == nil else { return }
+        guard article.isRedditPost, let commentsUrl = article.redditCommentsUrl else { return }
+
+        inFlightTasks[articleID] = Task {
+            do {
+                let result = try await Self.fetchRedditPost(commentsUrl: commentsUrl)
+                cache[articleID] = result
+            } catch {
+                // Preload failure is non-fatal — view will fetch on its own
+            }
+            inFlightTasks[articleID] = nil
+        }
+    }
+
+    /// Evict entries not in the given set of article IDs.
+    func evict(keeping articleIDs: Set<PersistentIdentifier>) {
+        for key in cache.keys where !articleIDs.contains(key) {
+            cache.removeValue(forKey: key)
+        }
+        for (key, task) in inFlightTasks where !articleIDs.contains(key) {
+            task.cancel()
+            inFlightTasks.removeValue(forKey: key)
+        }
+    }
+
+    /// Shared fetch logic — same as RedditPostView.loadPost() but static.
+    static func fetchRedditPost(commentsUrl: String) async throws -> CachedPost {
+        let jsonURL = commentsUrl.hasSuffix("/") ? commentsUrl + ".json" : commentsUrl + ".json"
+        guard let requestURL = URL(string: jsonURL) else {
+            throw URLError(.badURL)
+        }
+
+        var request = URLRequest(url: requestURL)
+        request.setValue("ios:com.today.app:v1.0 (by /u/TodayApp)", forHTTPHeaderField: "User-Agent")
+
+        let (data, _) = try await URLSession.shared.data(for: request)
+        let parser = RedditJSONParser()
+        let (post, comments) = try parser.parsePostWithComments(data: data)
+        return CachedPost(post: post, comments: comments)
+    }
+}

--- a/Today/Views/ArticlePagerView.swift
+++ b/Today/Views/ArticlePagerView.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+import SwiftData
+
+#if os(iOS)
+/// A paging container that renders articles in a TabView(.page) for train-car style swiping.
+/// Preloads adjacent Reddit post data for instant transitions.
+struct ArticlePagerView: View {
+    let context: [PersistentIdentifier]
+    let initialArticleID: PersistentIdentifier
+
+    @Environment(\.modelContext) private var modelContext
+    @State private var currentIndex: Int
+    private let postCache = RedditPostCache.shared
+
+    init(context: [PersistentIdentifier], initialArticleID: PersistentIdentifier) {
+        self.context = context
+        self.initialArticleID = initialArticleID
+        self._currentIndex = State(initialValue: context.firstIndex(of: initialArticleID) ?? 0)
+    }
+
+    var body: some View {
+        TabView(selection: $currentIndex) {
+            ForEach(Array(context.enumerated()), id: \.element) { index, articleID in
+                if let article = modelContext.model(for: articleID) as? Article {
+                    articleView(for: article, at: index)
+                        .tag(index)
+                }
+            }
+        }
+        .tabViewStyle(.page(indexDisplayMode: .never))
+        .onChange(of: currentIndex) { _, newIndex in
+            preloadAdjacent(around: newIndex)
+        }
+        .onAppear {
+            preloadAdjacent(around: currentIndex)
+        }
+    }
+
+    @ViewBuilder
+    private func articleView(for article: Article, at index: Int) -> some View {
+        let previousID = index > 0 ? context[index - 1] : nil
+        let nextID = index < context.count - 1 ? context[index + 1] : nil
+
+        if article.isRedditPost {
+            let cached = postCache.get(for: article.persistentModelID)
+            RedditPostView(
+                article: article,
+                previousArticleID: previousID,
+                nextArticleID: nextID,
+                onNavigateToPrevious: { _ in
+                    withAnimation { currentIndex = index - 1 }
+                },
+                onNavigateToNext: { _ in
+                    withAnimation { currentIndex = index + 1 }
+                },
+                cachedPost: cached?.post,
+                cachedComments: cached?.comments
+            )
+        } else {
+            ArticleDetailSimple(
+                article: article,
+                previousArticleID: previousID,
+                nextArticleID: nextID,
+                onNavigateToPrevious: { _ in
+                    withAnimation { currentIndex = index - 1 }
+                },
+                onNavigateToNext: { _ in
+                    withAnimation { currentIndex = index + 1 }
+                }
+            )
+        }
+    }
+
+    private func preloadAdjacent(around index: Int) {
+        // Preload ±2 articles for Reddit posts
+        let window = max(0, index - 2)...min(context.count - 1, index + 2)
+        let windowIDs = Set(window.map { context[$0] })
+
+        // Evict articles outside the window
+        postCache.evict(keeping: windowIDs)
+
+        // Preload adjacent Reddit articles
+        for i in window where i != index {
+            let articleID = context[i]
+            if let article = modelContext.model(for: articleID) as? Article,
+               article.isRedditPost {
+                postCache.preload(article: article)
+            }
+        }
+    }
+}
+#endif

--- a/Today/Views/RedditPostView.swift
+++ b/Today/Views/RedditPostView.swift
@@ -54,6 +54,10 @@ struct RedditPostView: View {
     let onNavigateToPrevious: (PersistentIdentifier) -> Void
     let onNavigateToNext: (PersistentIdentifier) -> Void
 
+    // Optional preloaded data from RedditPostCache (used by ArticlePagerView)
+    var cachedPost: ParsedRedditPost? = nil
+    var cachedComments: [RedditComment]? = nil
+
     @State private var post: ParsedRedditPost?
     @State private var comments: [RedditComment] = []
     @State private var isLoading = true
@@ -124,7 +128,7 @@ struct RedditPostView: View {
                         } else {
                             VStack(alignment: .leading, spacing: 4) {
                                 HStack {
-                                    Text("\(post.numComments) Comments")
+                                    Text("\(displayComments.count) Comments")
                                         .font(.headline)
                                         .fontWeight(.semibold)
                                     Spacer()
@@ -332,6 +336,17 @@ struct RedditPostView: View {
         isLoading = true
         errorMessage = nil
 
+        // Use preloaded cache if available
+        if let cachedPost, let cachedComments {
+            self.post = cachedPost
+            self.comments = cachedComments
+            #if os(macOS)
+            self.commentsWithChildren = computeCommentsWithChildren(cachedComments)
+            #endif
+            isLoading = false
+            return
+        }
+
         guard let commentsUrl = article.redditCommentsUrl else {
             errorMessage = "Invalid Reddit post URL"
             isLoading = false
@@ -339,25 +354,14 @@ struct RedditPostView: View {
         }
 
         do {
-            let jsonURL = commentsUrl.hasSuffix("/") ? commentsUrl + ".json" : commentsUrl + ".json"
-            guard let requestURL = URL(string: jsonURL) else {
-                throw RedditError.invalidURL
-            }
+            let result = try await RedditPostCache.fetchRedditPost(commentsUrl: commentsUrl)
 
-            var request = URLRequest(url: requestURL)
-            request.setValue("ios:com.today.app:v1.0 (by /u/TodayApp)", forHTTPHeaderField: "User-Agent")
-
-            let (data, _) = try await URLSession.shared.data(for: request)
-
-            let parser = RedditJSONParser()
-            let (parsedPost, parsedComments) = try parser.parsePostWithComments(data: data)
-
-            self.post = parsedPost
-            self.comments = parsedComments
+            self.post = result.post
+            self.comments = result.comments
 
             // Pre-compute which comments have children (for macOS collapse UI)
             #if os(macOS)
-            self.commentsWithChildren = computeCommentsWithChildren(parsedComments)
+            self.commentsWithChildren = computeCommentsWithChildren(result.comments)
             #endif
 
             isLoading = false
@@ -454,16 +458,8 @@ struct PostContentView: View {
                     .system(.title2, design: .serif, weight: .bold) :
                     .system(.title2, design: .default, weight: .bold))
 
-            // Meta info: subreddit, author, score, time
+            // Meta info: author, score, time
             HStack(spacing: 8) {
-                Text("r/\(post.subreddit)")
-                    .font(.subheadline)
-                    .foregroundStyle(accentColor.color)
-
-                Text("•")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-
                 Text("u/\(post.author)")
                     .font(.subheadline)
                     .foregroundStyle(accentColor.color)

--- a/Today/Views/TodayView.swift
+++ b/Today/Views/TodayView.swift
@@ -385,8 +385,13 @@ struct TodayView: View {
                 resetToToday()
             }
             .navigationDestination(item: $navigationState) { state in
+                #if os(iOS)
+                ArticlePagerView(
+                    context: state.context,
+                    initialArticleID: state.articleID
+                )
+                #else
                 if let article = modelContext.model(for: state.articleID) as? Article {
-                    // For Reddit posts, show combined post + comments view
                     if article.isRedditPost {
                         if !state.context.isEmpty,
                            let currentIndex = state.context.firstIndex(of: state.articleID) {
@@ -412,7 +417,7 @@ struct TodayView: View {
                                     }
                                 }
                             )
-                            .id(state.articleID)  // Force view refresh when article changes
+                            .id(state.articleID)
                         } else {
                             RedditPostView(
                                 article: article,
@@ -422,10 +427,7 @@ struct TodayView: View {
                                 onNavigateToNext: { _ in }
                             )
                         }
-                    }
-                    // For all other articles, show in-app article detail
-                    // Use the captured navigation context (stable across view updates)
-                    else if !state.context.isEmpty,
+                    } else if !state.context.isEmpty,
                        let currentIndex = state.context.firstIndex(of: state.articleID) {
                         let previousIndex = currentIndex - 1
                         let nextIndex = currentIndex + 1
@@ -459,6 +461,7 @@ struct TodayView: View {
                         )
                     }
                 }
+                #endif
             }
             .toolbar {
                 #if os(iOS)


### PR DESCRIPTION
## Summary

- Replaces simple swipe-to-navigate with `TabView(.page)` pager on iOS for smooth card-style swiping between articles (like Reddit's mobile app)
- Preloads adjacent Reddit post data (JSON + comments) in background via `RedditPostCache` for instant transitions
- Removes redundant subreddit name from Reddit post detail view (already shown in nav bar)
- Fixes comment count to reflect actual displayed comments (excludes filtered AutoModerator etc.)
- macOS navigation unchanged (keyboard shortcuts + toolbar buttons)

## Test plan

- [ ] Tap into any article, swipe left/right to page between articles
- [ ] Reddit posts: adjacent posts should load instantly (preloaded)
- [ ] Regular articles: should render immediately (local SwiftData content)
- [ ] Verify vertical scrolling still works within articles
- [ ] Verify image gallery swiping still works independently
- [ ] Verify macOS keyboard/button navigation is unaffected
- [ ] Verify comment count matches visible comments (no filtered counts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)