### PR TITLE
chore: sync agentic workflow template

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-ready.md
+++ b/.github/ISSUE_TEMPLATE/agent-ready.md
@@ -23,7 +23,7 @@ assignees: ''
 - [ ]
 - [ ]
 - [ ] Tests pass (unit + integration as appropriate)
-- [ ] Passes linting and code standards (PHPCS, ESLint)
+- [ ] Passes linting and code standards (project-specific)
 - [ ] Code review approved
 
 ## Scope
@@ -51,16 +51,16 @@ assignees: ''
 <!-- Files to create, modify, or use as reference -->
 
 ```
-- /plugins/plugin-name/path/to/modify.php
-- /plugins/plugin-name/path/to/pattern-reference.php (for reference)
+- src/path/to/file-to-modify.ext
+- src/path/to/pattern-reference.ext  (for reference)
 ```
 
 **Patterns to follow:**
 
 <!-- Name specific patterns, link to examples in the codebase -->
 
-- See `/plugins/prc-platform-core/...` for similar implementation
-- Follow VIP coding standards
+- See `src/...` for similar implementation
+- Follow project coding standards
 
 **Dependencies:**
 
@@ -72,7 +72,7 @@ assignees: ''
 
 <!-- How should this be tested? What test files to create/update? -->
 
-- PHPUnit tests in `/tests/`
+- Add tests to `tests/` or the project's test directory
 -
 
 ## Complexity
@@ -111,5 +111,5 @@ TIPS FOR GOOD AGENT ISSUES:
 - Combine unrelated changes
 - Skip the context section
 
-See docs/agentic-development-guide.md for full guidelines.
+See docs/AGENTIC_DEVELOPMENT.md for full guidelines.
 -->

--- a/.github/agents/issue-screener.agent.md
+++ b/.github/agents/issue-screener.agent.md
@@ -1,0 +1,212 @@
+---
+description: 'Screens the open issue backlog for agent-readiness candidates: scores each issue against a rubric, posts a structured comment with improvement guidance and a pre-filled agent-ready template draft, and applies the agent-candidate label to high-scoring issues.'
+tools:
+    - '*'
+---
+
+# Issue Screener Agent (Claude-Powered)
+
+You are an Issue Screener Agent. Your job is to survey the open issue backlog, evaluate each issue's fitness for agentic execution, and surface the best candidates for human review.
+
+**You NEVER apply the `agent-ready` label** — that decision belongs to a human. You apply `agent-candidate` and leave a detailed comment with your reasoning and a pre-filled template draft.
+
+---
+
+## Overview
+
+Well-scoped issues with clear acceptance criteria, file references, and bounded scope can be executed end-to-end by AI coding agents (Claude Code, Codex, Copilot). Your job is to identify issues in the backlog that are close to that bar but haven't been labeled yet.
+
+You operate as a batch process over all open issues. You do not implement anything. You only read, score, comment, and label.
+
+---
+
+## Process
+
+Follow these steps in order.
+
+### Step 1: Fetch the Open Issue Backlog
+
+Use the GitHub CLI to retrieve all open issues not yet labeled `agent-ready` or `agent-candidate`:
+
+```bash
+gh issue list \
+  --repo $(gh repo view --json nameWithOwner -q .nameWithOwner) \
+  --state open \
+  --limit 200 \
+  --json number,title,body,labels,url,createdAt \
+  | jq '[.[] | select(
+      (.labels | map(.name) | index("agent-ready") | not) and
+      (.labels | map(.name) | index("agent-candidate") | not)
+    )]'
+```
+
+If the result is empty, print "No unscreened open issues found." and stop.
+
+Process each issue one at a time.
+
+### Step 2: Score Each Issue Against the Rubric
+
+For each issue, compute a score using the rubric below.
+
+#### Positive Signals (add points)
+
+| Signal | Points | How to Detect |
+|--------|--------|---------------|
+| Has expected vs actual behavior described | +2 | Body contains expected/actual pairing, or a before/after framing |
+| References a specific file, class, module, or API by name | +2 | Mentions a file path, a named class/function, a REST route, or a specific library method |
+| Has testable acceptance criteria | +2 | Contains `- [ ]` checkbox items that describe verifiable outcomes |
+| Is clearly a code bug (not content or design judgment) | +1 | Mentions errors, exceptions, stack traces, broken functionality, or regression |
+| Has reproduction steps or error logs | +1 | Contains numbered steps, a stack trace, a console error, or a code block with logs |
+| Scope is bounded (not architectural) | +1 | Issue can plausibly be completed in one PR; does not require cross-cutting design decisions |
+
+#### Negative Signals (subtract points)
+
+| Signal | Points | How to Detect |
+|--------|--------|---------------|
+| Just a URL with minimal description | -3 | Body is mostly a URL with fewer than two sentences of explanation |
+| Requires human visual or editorial judgment | -2 | Language like "looks wrong", "design review needed", "content update", "check with editorial" |
+| Vague improvement language | -1 | Uses "improve", "enhance", "make better", "clean up" without a concrete problem statement |
+
+#### Score Interpretation
+
+- **≥ 7**: Strong candidate — likely ready to promote with minor editing
+- **5–6**: Good candidate — will benefit from human review
+- **< 5**: Not ready — skip; do not post a comment or apply a label
+
+### Step 3: Post the Screener Comment
+
+For each issue that scores ≥ 5, post a comment using `gh issue comment`. The comment must follow this format:
+
+```markdown
+## Issue Screener Agent — Candidate Report
+
+> **This is an automated assessment.** A human must review and apply the `agent-ready` label if
+> this issue is ready for agent execution. The `agent-candidate` label has been applied.
+
+---
+
+### Score: X / 10
+
+| Signal | Points |
+|--------|--------|
+| [describe each signal detected] | [+N or -N] |
+| **Total** | **X** |
+
+### Rationale
+
+[2–4 sentences explaining the score. What makes this a good candidate? What would improve it?]
+
+---
+
+### Draft: Agent-Ready Template
+
+Below is a pre-filled agent-ready template based on this issue's content.
+A human should review and refine before promoting to `agent-ready`.
+
+---
+
+## Summary
+
+[1 sentence extracted or synthesized from the issue title and body]
+
+## Context
+
+[Extracted from the issue. Synthesize the "why" if not explicit.]
+
+## Acceptance Criteria
+
+[Extract any existing checkboxes. If none, draft 3–5 testable criteria. Always include:]
+
+- [ ] Tests pass (unit + integration as appropriate)
+- [ ] Passes linting and code standards (project-specific)
+- [ ] Code review approved
+
+## Scope
+
+**In scope:**
+
+[Extract what the issue explicitly asks for as bullet points]
+
+**Out of scope:**
+
+[Draft conservative exclusions based on what the issue does NOT mention]
+
+## Technical Notes
+
+**Key files:**
+
+[List any file paths, class names, or API routes mentioned. If none, write "Not specified."]
+
+**Patterns to follow:**
+
+- Follow project coding standards
+- [Add any specific patterns mentioned in the issue]
+
+**Dependencies:**
+
+[Note any APIs, libraries, or external systems mentioned]
+
+**Testing approach:**
+
+- [Draft 1–2 testing suggestions appropriate to the issue type]
+
+## Complexity
+
+- [ ] `complexity:low` — Single file, obvious pattern, quick fix
+- [x] `complexity:medium` — Multiple files, follows established patterns
+- [ ] `complexity:high` — Architectural decisions, new patterns, needs planning phase
+
+## Agent Readiness
+
+- [ ] Scope is bounded (can be done in one PR)
+- [ ] Success criteria are measurable
+- [ ] Context explains the "why"
+- [ ] Patterns are linked, not assumed
+- [ ] No external blockers (APIs available, dependencies installed)
+
+---
+
+_Issue Screener Agent — [Configure](.github/agents/issue-screener.agent.md)_
+```
+
+Post the comment:
+
+```bash
+gh issue comment ${ISSUE_NUMBER} --body "${COMMENT_BODY}"
+```
+
+### Step 4: Apply the `agent-candidate` Label
+
+After posting the comment, apply the label:
+
+```bash
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+gh issue edit ${ISSUE_NUMBER} --repo "${REPO}" --add-label "agent-candidate"
+```
+
+If the label does not exist, log the error and continue to the next issue.
+
+### Step 5: Print Run Summary
+
+After processing all issues:
+
+```
+Issue Screener Agent Run Summary
+=================================
+Total issues evaluated: X
+Candidates (score ≥ 5): X
+  - #NNN "Issue title" (score: X)
+Skipped (score < 5): X
+Errors: X
+```
+
+---
+
+## Important Rules
+
+- **Never apply `agent-ready`** — only `agent-candidate`. Promotion is always a human decision.
+- **Never modify issue bodies** — only post comments.
+- **Never close or lock issues**.
+- **Be conservative with scores** — false negatives are better than false positives.
+- **Graceful degradation** — if one issue fails, log the error and continue. Never abort the entire run.
+- **Idempotency** — the label check at Step 1 skips already-labeled issues.

--- a/.github/workflows/agent-ready-trigger.yml
+++ b/.github/workflows/agent-ready-trigger.yml
@@ -1,5 +1,18 @@
-# Automatically triggers Claude Code when an issue receives the 'agent-ready' label.
-# Claude will read the issue, create a plan, and implement the solution.
+# Fires when an issue receives the 'agent-ready' label.
+# Routes to the AI agent configured in the AGENT_PROVIDER repository variable.
+#
+# Supported providers:
+#   claude        → Claude Code via anthropics/claude-code-action (default, fully supported)
+#   openai-codex  → OpenAI Codex CLI (stub — extend for your setup)
+#   copilot       → GitHub Copilot via gh-aw (stub — extend for your setup)
+#   custom        → repository_dispatch event (bring your own listener)
+#
+# Setup:
+#   1. Set AGENT_PROVIDER in Settings → Secrets and variables → Variables
+#   2. Add the required secret for your chosen provider (see README)
+#   3. Run the Setup Labels workflow once to create all labels
+#
+# If AGENT_PROVIDER is not set, the workflow defaults to claude.
 
 name: Agent-Ready Auto-Trigger
 
@@ -7,10 +20,21 @@ on:
   issues:
     types: [labeled]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
+  # ─────────────────────────────────────────────────────────────────────────────
+  # CLAUDE (default)
+  # Uses Claude Code with Compound Engineering for complexity-aware execution.
+  #
+  # complexity:high  → /ce-plan first, human approves via /approve-plan, then /ce-work
+  # complexity:low/medium (or absent) → /ce-work directly
+  # ─────────────────────────────────────────────────────────────────────────────
   trigger-claude:
-    # Only run when the 'agent-ready' label is added
-    if: github.event.label.name == 'agent-ready'
+    if: |
+      github.event.label.name == 'agent-ready' &&
+      (vars.AGENT_PROVIDER == 'claude' || vars.AGENT_PROVIDER == '')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -20,42 +44,206 @@ jobs:
       actions: read
 
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
 
-      - name: Run Claude Code
-        id: claude
+      - name: Determine complexity
+        id: complexity
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.issue.labels.map(l => l.name);
+            const isHigh = labels.includes('complexity:high');
+            console.log('Issue labels:', labels.join(', '));
+            console.log('complexity:high:', isHigh);
+            core.setOutput('is_high', isHigh ? 'true' : 'false');
+
+      # ── HIGH COMPLEXITY: plan first, then gate on /approve-plan ──────────────
+      - name: Run Claude Code — Planning Phase (complexity:high)
+        id: claude-plan
+        if: steps.complexity.outputs.is_high == 'true'
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-
-          # Allow Claude to read CI results and manage PRs
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |
             actions: read
-
-          # Custom prompt for agent-ready issues
           prompt: |
-            You are working on issue #${{ github.event.issue.number }}.
+            You are planning the implementation for issue #${{ github.event.issue.number }}.
 
-            Issue Title: ${{ github.event.issue.title }}
+            Issue title: ${{ github.event.issue.title }}
+
+            This is a complexity:high issue. Your job is to PLAN, not implement.
 
             Instructions:
-            1. Read the full issue description carefully
-            2. Follow the acceptance criteria exactly
-            3. Stay within the defined scope (respect "Out of scope" boundaries)
+            1. Read the full issue body carefully
+            2. Invoke /ce-plan with the issue description as input to generate a structured
+               implementation plan
+            3. Commit the generated plan file to docs/plans/ on a new branch named
+               plan/issue-${{ github.event.issue.number }}
+            4. After committing, post a comment on the issue with:
+               - A link to the plan file (use the GitHub file URL)
+               - The message: "Implementation plan is ready for review. Reply /approve-plan
+                 to begin implementation, or comment with feedback to revise the plan."
+            5. Do NOT write any application code
+            6. Do NOT open a pull request
+
+            After posting the comment, verify that a plan file was committed to docs/plans/.
+            If /ce-plan was unavailable or the commit failed, post a comment explaining what
+            happened instead of the approval-request message.
+
+      # ── LOW/MEDIUM COMPLEXITY: execute directly ──────────────────────────────
+      - name: Run Claude Code — Direct Execution (complexity:low/medium)
+        id: claude-work
+        if: steps.complexity.outputs.is_high == 'false'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read
+          prompt: |
+            You are implementing issue #${{ github.event.issue.number }}.
+
+            Issue title: ${{ github.event.issue.title }}
+
+            Instructions:
+            1. Read the full issue body carefully
+            2. Invoke /ce-work with the issue as input to implement the feature
+            3. Stay within the defined scope — "Out of scope" is a hard boundary
             4. Follow the patterns referenced in Technical Notes
-            5. Create a PR with your implementation
-            6. Include tests as specified
-            7. Ensure code passes linting (PHPCS, ESLint)
+            5. Open a PR using the agent-generated PR template
+            6. Add the 'agent-generated' label to the PR
+            7. Reference the issue in the PR body: "Closes #${{ github.event.issue.number }}"
 
-            Important:
-            - Do NOT implement items listed as "Out of scope"
-            - Reference the issue number in your PR description
-            - If you're blocked or unclear on something, comment on the issue asking for clarification rather than guessing
+            If you are blocked or unclear on something, post a comment on the issue
+            asking for clarification rather than guessing.
 
-            Begin by reading the issue and creating an implementation plan.
+      - name: Check for missing CLAUDE_CODE_OAUTH_TOKEN
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: [
+                '⚠️ **Agent setup incomplete**',
+                '',
+                'The Claude Code workflow failed. This is usually caused by a missing `CLAUDE_CODE_OAUTH_TOKEN` secret.',
+                '',
+                'To fix: go to **Settings → Secrets and variables → Secrets** and add `CLAUDE_CODE_OAUTH_TOKEN`.',
+                '',
+                'See the [README](../blob/main/README.md) for setup instructions.'
+              ].join('\n')
+            });
 
-          # Use appropriate model and tools
-          claude_args: '--allowed-tools Bash(git:*,npm:*,composer:*) Edit Read Write'
+  # ─────────────────────────────────────────────────────────────────────────────
+  # OPENAI CODEX (stub)
+  # TODO: extend this job for your Codex setup.
+  # See https://github.com/openai/codex for the CLI reference.
+  # ─────────────────────────────────────────────────────────────────────────────
+  trigger-openai-codex:
+    if: |
+      github.event.label.name == 'agent-ready' &&
+      vars.AGENT_PROVIDER == 'openai-codex'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Codex
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          # TODO: Replace this stub with your Codex invocation.
+          # Example using the Codex CLI:
+          #
+          #   npm install -g @openai/codex
+          #   codex --approval-mode full-auto \
+          #     --model o4-mini \
+          #     "Implement issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}"
+          #
+          # After implementation, create a PR:
+          #   git push origin HEAD
+          #   gh pr create --title "..." --body "Closes #${ISSUE_NUMBER}"
+          #
+          echo "OpenAI Codex provider stub — configure this step for your setup"
+          echo "Issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}"
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # GITHUB COPILOT via gh-aw (stub)
+  # TODO: extend this job for your gh-aw setup.
+  # See https://github.com/github/gh-aw for the CLI reference.
+  # ─────────────────────────────────────────────────────────────────────────────
+  trigger-copilot:
+    if: |
+      github.event.label.name == 'agent-ready' &&
+      vars.AGENT_PROVIDER == 'copilot'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Copilot via gh-aw
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          # TODO: Replace this stub with your gh-aw invocation.
+          # Prerequisites:
+          #   1. Install gh-aw: gh extension install github/gh-aw
+          #   2. Author a workflow markdown file (e.g., .github/workflows/implement-issue.md)
+          #   3. Compile it: gh aw compile implement-issue
+          #
+          # Then invoke the compiled workflow:
+          #   gh aw run implement-issue --issue "${ISSUE_NUMBER}"
+          #
+          echo "GitHub Copilot (gh-aw) provider stub — configure this step for your setup"
+          echo "Issue #${ISSUE_NUMBER}"
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # CUSTOM — repository_dispatch
+  # Emits an event that a listener workflow in this repo can consume.
+  # Note: repository_dispatch events are NOT cross-repo. Your listener workflow
+  # must be in this same repository. For outbound HTTP to an external agent,
+  # replace the github-script step with a curl call.
+  # ─────────────────────────────────────────────────────────────────────────────
+  trigger-custom:
+    if: |
+      github.event.label.name == 'agent-ready' &&
+      vars.AGENT_PROVIDER == 'custom'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Dispatch agent-ready event
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event_type: 'agent-ready',
+              client_payload: {
+                issue_number: context.payload.issue.number,
+                issue_title: context.payload.issue.title,
+                issue_body: context.payload.issue.body,
+                issue_url: context.payload.issue.html_url,
+                labels: context.payload.issue.labels.map(l => l.name)
+              }
+            });
+            console.log(`Dispatched agent-ready event for issue #${context.payload.issue.number}`);

--- a/.github/workflows/issue-screener.yml
+++ b/.github/workflows/issue-screener.yml
@@ -1,0 +1,241 @@
+# Scans open issues for agent-readiness candidates.
+# Runs weekly and on manual dispatch.
+#
+# This is the lightweight (no-LLM) screener. It scores issues structurally
+# using the rubric below and applies 'agent-candidate' to high-scoring issues.
+# A human must review candidates and apply 'agent-ready' to start execution.
+#
+# For the Claude-powered screener (richer analysis, draft templates in comments),
+# see .github/agents/issue-screener.agent.md and use it with Claude Code or
+# anthropics/claude-code-action.
+#
+# The screener NEVER applies 'agent-ready' — that decision belongs to a human.
+
+name: Issue Screener
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Every Monday at 9am UTC
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  screen-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Screen open issues for agent-readiness
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Fetch open issues not yet labeled agent-ready or agent-candidate
+            const { data: allIssues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100
+            });
+
+            const issues = allIssues.filter(issue => {
+              // Skip PRs (GitHub returns them in issues API)
+              if (issue.pull_request) return false;
+              const labelNames = issue.labels.map(l => l.name);
+              return !labelNames.includes('agent-ready') && !labelNames.includes('agent-candidate');
+            });
+
+            if (issues.length === 0) {
+              console.log('No unscreened open issues found.');
+              return;
+            }
+
+            console.log(`Screening ${issues.length} issue(s)...`);
+
+            // ── SCORING RUBRIC ────────────────────────────────────────────────
+            //
+            // Positive signals (+points):
+            //   +2  Has expected vs actual behavior described
+            //   +2  References a specific file, class, module, or API by name
+            //   +2  Has testable acceptance criteria (checkboxes)
+            //   +1  Is clearly a code bug (not content or design judgment)
+            //   +1  Has reproduction steps or error logs
+            //   +1  Scope is bounded (likely completable in one PR)
+            //
+            // Negative signals (-points):
+            //   -3  Just a URL with minimal description
+            //   -2  Requires human visual or editorial judgment
+            //   -1  Vague improvement language
+            //
+            // Score ≥ 7: Strong candidate
+            // Score 5–6: Good candidate
+            // Score < 5: Skip
+
+            function scoreIssue(issue) {
+              const body = issue.body || '';
+              const title = issue.title || '';
+              const combined = title + ' ' + body;
+              let score = 0;
+              const signals = [];
+
+              // Positive: expected vs actual behavior
+              if (/expected|actual|should|instead/i.test(body) &&
+                  /(expected|should)[\s\S]{0,200}(actual|instead)/i.test(body)) {
+                score += 2;
+                signals.push({ signal: 'Has expected vs actual behavior', points: 2 });
+              }
+
+              // Positive: references specific file/class/module/API
+              if (/[a-zA-Z0-9_\-]+\.(js|ts|py|rb|go|java|php|swift|rs|kt|cs|cpp|h|css|scss|md)|[A-Z][a-zA-Z]+Controller|[A-Z][a-zA-Z]+Service|[A-Z][a-zA-Z]+Model|\/api\/|GET |POST |PUT |DELETE /i.test(body)) {
+                score += 2;
+                signals.push({ signal: 'References specific file/class/module/API', points: 2 });
+              }
+
+              // Positive: testable acceptance criteria (checkboxes)
+              const checkboxCount = (body.match(/- \[[ x]\]/g) || []).length;
+              if (checkboxCount >= 2) {
+                score += 2;
+                signals.push({ signal: `Has ${checkboxCount} acceptance criteria checkbox(es)`, points: 2 });
+              } else if (checkboxCount === 1) {
+                score += 1;
+                signals.push({ signal: 'Has 1 acceptance criteria checkbox', points: 1 });
+              }
+
+              // Positive: clearly a code bug
+              if (/error|exception|stack trace|console\.error|TypeError|undefined is not|cannot read|failed|broken|crash|bug/i.test(body)) {
+                score += 1;
+                signals.push({ signal: 'Mentions error/bug/exception', points: 1 });
+              }
+
+              // Positive: reproduction steps or logs
+              if (/steps to reproduce|reproduction:|repro:|```[\s\S]*?```|^\d+\. /m.test(body)) {
+                score += 1;
+                signals.push({ signal: 'Has reproduction steps or code/log block', points: 1 });
+              }
+
+              // Positive: scope is bounded
+              const wordCount = body.split(/\s+/).length;
+              if (wordCount > 50 && wordCount < 800 &&
+                  !/(redesign|overhaul|rewrite|revamp|rethink|entire|whole system|everything)/i.test(body)) {
+                score += 1;
+                signals.push({ signal: 'Scope appears bounded', points: 1 });
+              }
+
+              // Negative: just a URL
+              const nonUrlContent = body.replace(/https?:\/\/[^\s]+/g, '').trim();
+              if (nonUrlContent.split(/\s+/).length < 10) {
+                score -= 3;
+                signals.push({ signal: 'Mostly a URL with minimal description', points: -3 });
+              }
+
+              // Negative: visual/editorial judgment required
+              if (/looks wrong|design review|check with|content update|visual|styling|layout|UI feedback/i.test(body)) {
+                score -= 2;
+                signals.push({ signal: 'Requires visual/editorial judgment', points: -2 });
+              }
+
+              // Negative: vague improvement language
+              if (/\b(improve|enhance|make better|clean up|refactor)\b/i.test(body) &&
+                  !/specific|exactly|in particular|specifically/i.test(body)) {
+                score -= 1;
+                signals.push({ signal: 'Vague improvement language without specifics', points: -1 });
+              }
+
+              return { score, signals };
+            }
+
+            let candidates = 0, skipped = 0, errors = 0;
+            const candidateList = [];
+
+            for (const issue of issues) {
+              const { score, signals } = scoreIssue(issue);
+
+              if (score < 5) {
+                console.log(`  #${issue.number} (score: ${score}) — skipped`);
+                skipped++;
+                continue;
+              }
+
+              // Build signal table for comment
+              const signalRows = signals.map(s =>
+                `| ${s.signal} | ${s.points > 0 ? '+' : ''}${s.points} |`
+              ).join('\n');
+
+              const comment = [
+                '## Issue Screener — Candidate Report',
+                '',
+                '> **This is an automated structural assessment.** A human must review and apply',
+                '> the `agent-ready` label to start agent execution.',
+                '> The `agent-candidate` label has been applied to this issue.',
+                '',
+                '---',
+                '',
+                `### Score: ${score} / 10`,
+                '',
+                '| Signal | Points |',
+                '|--------|--------|',
+                signalRows,
+                `| **Total** | **${score}** |`,
+                '',
+                '### What Would Improve This Issue',
+                '',
+                ...(score >= 7 ? [
+                  'This issue scores strongly. To promote to `agent-ready`:',
+                  '',
+                  '- [ ] Verify scope is bounded (one PR)',
+                  '- [ ] Add "Out of scope" exclusions if missing',
+                  '- [ ] Link to specific files or patterns to follow',
+                ] : [
+                  'To reach `agent-ready` status, consider:',
+                  '',
+                  ...(!signals.find(s => s.signal.includes('acceptance criteria')) ? ['- [ ] Add acceptance criteria checkboxes (specific, testable criteria)'] : []),
+                  ...(!signals.find(s => s.signal.includes('file/class')) ? ['- [ ] Reference specific files, classes, or APIs in the codebase'] : []),
+                  ...(!signals.find(s => s.signal.includes('reproduction')) ? ['- [ ] Add reproduction steps or paste a relevant error log'] : []),
+                  '- [ ] Define scope explicitly (what is and is not included)',
+                ]),
+                '',
+                '---',
+                '',
+                `_Issue Screener — automated structural check · [Configure](.github/workflows/issue-screener.yml)_`,
+              ].join('\n');
+
+              try {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: comment
+                });
+
+                try {
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    labels: ['agent-candidate']
+                  });
+                } catch (labelErr) {
+                  console.error(`  Could not apply agent-candidate to #${issue.number}: ${labelErr.message}`);
+                  // Continue — the comment was posted; the label is a bonus
+                }
+
+                console.log(`  #${issue.number} (score: ${score}) — candidate`);
+                candidateList.push({ number: issue.number, title: issue.title, score });
+                candidates++;
+              } catch (err) {
+                console.error(`  #${issue.number} — error: ${err.message}`);
+                errors++;
+              }
+            }
+
+            // Run summary
+            console.log('');
+            console.log('Issue Screener Run Summary');
+            console.log('==========================');
+            console.log(`Total issues evaluated: ${issues.length}`);
+            console.log(`Candidates (score ≥ 5): ${candidates}`);
+            candidateList.forEach(c => console.log(`  - #${c.number} "${c.title}" (score: ${c.score})`));
+            console.log(`Skipped (score < 5): ${skipped}`);
+            console.log(`Errors: ${errors}`);

--- a/.github/workflows/plan-approval-gate.yml
+++ b/.github/workflows/plan-approval-gate.yml
@@ -1,0 +1,136 @@
+# Listens for '/approve-plan' comments on issues and resumes ce-work execution.
+#
+# This workflow is part of the complexity:high flow:
+#   1. agent-ready-trigger.yml fires, Claude runs /ce-plan, commits plan to docs/plans/
+#   2. Claude posts a comment asking for /approve-plan
+#   3. This workflow fires on that comment, verifies the commenter, then runs /ce-work
+#
+# Only collaborators with write or admin permission can approve plans.
+# Non-collaborators receive a reply comment but no agent run is started.
+
+name: Plan Approval Gate
+
+on:
+  issue_comment:
+    types: [created]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  handle-approve-plan:
+    # Only fire on /approve-plan comments (not PR comments, not other content)
+    if: |
+      github.event.issue.pull_request == null &&
+      startsWith(github.event.comment.body, '/approve-plan')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check commenter permissions
+        id: permission-check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const commenter = context.payload.comment.user.login;
+            const issueNumber = context.payload.issue.number;
+
+            let permLevel;
+            try {
+              const result = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: commenter
+              });
+              permLevel = result.data.permission;
+            } catch (err) {
+              // User is not a collaborator at all
+              permLevel = 'none';
+            }
+
+            const allowed = ['write', 'admin'].includes(permLevel);
+            console.log(`Commenter ${commenter} has permission: ${permLevel} — allowed: ${allowed}`);
+
+            if (!allowed) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: `@${commenter} Only collaborators with write access can approve plans. Your approval was not processed.`
+              });
+            }
+
+            core.setOutput('allowed', allowed ? 'true' : 'false');
+
+      - name: Check for existing PR (idempotency)
+        id: pr-check
+        if: steps.permission-check.outputs.allowed == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueNumber = context.payload.issue.number;
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open'
+            });
+
+            // Check if any open PR references this issue
+            const existing = prs.find(pr =>
+              pr.body && (
+                pr.body.includes(`Closes #${issueNumber}`) ||
+                pr.body.includes(`closes #${issueNumber}`) ||
+                pr.body.includes(`Fixes #${issueNumber}`) ||
+                pr.body.includes(`fixes #${issueNumber}`)
+              )
+            );
+
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: `Implementation is already in progress: ${existing.html_url}`
+              });
+              core.setOutput('already_running', 'true');
+            } else {
+              core.setOutput('already_running', 'false');
+            }
+
+      - name: Run Claude Code with /ce-work
+        if: |
+          steps.permission-check.outputs.allowed == 'true' &&
+          steps.pr-check.outputs.already_running == 'false'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            You are implementing issue #${{ github.event.issue.number }}.
+
+            Issue title: ${{ github.event.issue.title }}
+
+            A human has approved the plan for this issue. Your job is to implement it.
+
+            Instructions:
+            1. Find the plan file in docs/plans/ that corresponds to this issue
+               (look for a recent plan file — check file dates and titles)
+            2. If a plan file exists, invoke /ce-work with the plan file path as input
+            3. If no plan file exists, invoke /ce-work directly with the issue as context
+            4. Implement the feature per the plan or issue
+            5. Open a PR using the agent-generated PR template
+            6. Add the 'agent-generated' label to the PR
+
+            Important:
+            - Stay within the issue's defined scope ("Out of scope" is a hard boundary)
+            - Reference the issue number in the PR: "Closes #${{ github.event.issue.number }}"
+            - If blocked or uncertain, comment on the issue asking for clarification
+
+          additional_permissions: |
+            actions: read

--- a/.github/workflows/setup-labels.yml
+++ b/.github/workflows/setup-labels.yml
@@ -1,0 +1,111 @@
+# One-time setup: syncs all labels from .github/LABELS.yml into this repository.
+#
+# Run this once after using the template to create your repo:
+#   Actions → Setup Labels → Run workflow
+#
+# This workflow is idempotent — running it multiple times only updates colors
+# and descriptions; it never deletes labels or fails on existing labels.
+
+name: Setup Labels
+
+on:
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  sync-labels:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Sync labels from LABELS.yml
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            const labelsFile = fs.readFileSync('.github/LABELS.yml', 'utf8');
+
+            // Minimal YAML parser for our known label format (avoids js-yaml dependency).
+            // Handles: array entries starting with "- ", key: value lines, and # comments.
+            const lines = labelsFile.split('\n');
+            const labels = [];
+            let current = null;
+            for (const rawLine of lines) {
+              const line = rawLine.trim();
+              if (!line || line.startsWith('#')) continue;
+              if (line.startsWith('- ')) {
+                if (current && current.name) labels.push(current);
+                current = {};
+                const rest = line.slice(2).trim();
+                if (rest.includes(':')) {
+                  const colonIdx = rest.indexOf(':');
+                  const key = rest.slice(0, colonIdx).trim();
+                  const val = rest.slice(colonIdx + 1).trim().replace(/^['"]|['"]$/g, '');
+                  current[key] = val;
+                }
+              } else if (current && line.includes(':')) {
+                const colonIdx = line.indexOf(':');
+                const key = line.slice(0, colonIdx).trim();
+                const val = line.slice(colonIdx + 1).trim().replace(/^['"]|['"]$/g, '');
+                current[key] = val;
+              }
+            }
+            if (current && current.name) labels.push(current);
+
+            if (!Array.isArray(labels)) {
+              core.setFailed('LABELS.yml must be a YAML array of label objects');
+              return;
+            }
+
+            let created = 0, updated = 0, errors = 0;
+
+            for (const label of labels) {
+              if (!label.name) continue; // skip comment-only entries
+
+              try {
+                // Try to create; if it exists, update instead
+                try {
+                  await github.rest.issues.createLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: label.name,
+                    color: label.color,
+                    description: label.description || ''
+                  });
+                  console.log(`✓ Created: ${label.name}`);
+                  created++;
+                } catch (err) {
+                  if (err.status === 422) {
+                    // Label already exists — update it
+                    await github.rest.issues.updateLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      name: label.name,
+                      color: label.color,
+                      description: label.description || ''
+                    });
+                    console.log(`↻ Updated: ${label.name}`);
+                    updated++;
+                  } else {
+                    throw err;
+                  }
+                }
+              } catch (err) {
+                console.error(`✗ Error on label "${label.name}": ${err.message}`);
+                errors++;
+              }
+            }
+
+            console.log('');
+            console.log(`Label sync complete: ${created} created, ${updated} updated, ${errors} errors`);
+
+            if (errors > 0) {
+              core.setFailed(`${errors} label(s) failed to sync. Check the log above.`);
+            }

--- a/docs/AGENTIC_DEVELOPMENT.md
+++ b/docs/AGENTIC_DEVELOPMENT.md
@@ -3,16 +3,29 @@
 ## Writing Issues That Agents Can Execute
 
 **Version:** 1.0
-**Date:** February 2026
-**Audience:** Pew Research Center Engineering Team
+**Date:** June 2026
+**Audience:** Engineering teams adopting AI-assisted development
 
 ---
 
 ## The Core Idea
 
-AI coding agents can take well-scoped issues 80-90% to completion before human review. The key word is **well-scoped**. A vague issue produces vague code. A precise issue produces precise code.
+AI coding agents can take well-scoped issues 80–90% to completion before human review. The key word is **well-scoped**. A vague issue produces vague code. A precise issue produces precise code.
 
-This guide teaches you how to write issues that agents can actually execute.
+This guide teaches you how to write issues that agents can actually execute, how to configure the workflow for your chosen provider, and how to integrate Compound Engineering when using Claude.
+
+---
+
+## Provider Overview
+
+| Provider | AGENT_PROVIDER value | Required secret | Notes |
+|----------|---------------------|-----------------|-------|
+| Claude + Compound Engineering | `claude` (default) | `CLAUDE_CODE_OAUTH_TOKEN` | Full support — complexity-aware, planning phase for high complexity |
+| OpenAI Codex | `openai-codex` | `OPENAI_API_KEY` | Stub — configure the `trigger-openai-codex` job |
+| GitHub Copilot (gh-aw) | `copilot` | _(gh-aw setup)_ | Stub — configure the `trigger-copilot` job |
+| Custom / bring-your-own | `custom` | _(your own)_ | Dispatches `repository_dispatch` event; add your listener |
+
+Set `AGENT_PROVIDER` in **Settings → Secrets and variables → Variables**. If not set, the workflow defaults to `claude`.
 
 ---
 
@@ -23,12 +36,10 @@ This guide teaches you how to write issues that agents can actually execute.
 State what needs to happen in a single sentence. If you can't, the scope is too big.
 
 **❌ Bad:**
-
-> Improve the PDF extraction system
+> Improve the data pipeline
 
 **✅ Good:**
-
-> Add REST API endpoints for retrieving extracted text in plain, markdown, and JSON formats
+> Add a REST endpoint that returns the latest pipeline run status as JSON
 
 ---
 
@@ -42,8 +53,7 @@ Agents don't have institutional knowledge. Tell them:
 - How it fits into the bigger picture
 
 **Example:**
-
-> LLMs and research tools need programmatic access to extracted topline data. Currently, content is only accessible via the WordPress admin. REST endpoints enable integration with external tools like NotebookLM, custom chatbots, and research pipelines.
+> External monitoring tools need programmatic access to pipeline status. Currently the status is only visible in the admin dashboard. A REST endpoint enables integration with Datadog, PagerDuty, and custom alerting scripts.
 
 ---
 
@@ -52,178 +62,104 @@ Agents don't have institutional knowledge. Tell them:
 Define "done" with measurable criteria. Each criterion should be testable.
 
 **❌ Vague:**
-
 - [ ] API works correctly
 - [ ] Good error handling
 
 **✅ Specific:**
-
-- [ ] `GET /prc-api/v3/pdf-extraction/text/{id}` returns extracted text
-- [ ] Returns 404 with error message when extraction doesn't exist
-- [ ] Returns 400 when format parameter is invalid
-- [ ] Response includes `X-OCR-Provider` and `X-Extraction-Date` headers
-- [ ] All endpoints require no authentication (public data)
-- [ ] Unit tests cover success and error cases
+- [ ] `GET /api/v1/pipeline/status` returns `{ status, last_run_at, duration_ms }`
+- [ ] Returns 404 when pipeline has never run
+- [ ] Returns 503 when pipeline is currently failing
+- [ ] Response includes `Cache-Control: no-cache` header
+- [ ] Unit tests cover success, 404, and 503 cases
 
 ---
 
 ### 4. Scope Boundaries (In/Out)
 
-Explicitly state what's included and excluded. Agents will try to be helpful — sometimes too helpful. Boundaries prevent scope creep.
+Explicitly state what's included and excluded. Agents try to be helpful — sometimes too helpful. Boundaries prevent scope creep.
 
 **Example:**
-
 ```
 In scope:
-- Three GET endpoints (status, text, list)
+- GET endpoint for current status
 - JSON response format
-- Basic error handling
+- Error handling for missing/failed pipeline
 - Unit tests
 
 Out of scope:
-- Authentication/rate limiting (Phase 2)
-- Caching layer (separate issue)
-- Admin UI for API keys
-- Webhook notifications
+- Authentication (existing endpoints are public)
+- Historical run data (separate issue)
+- Webhook notifications for status changes
 ```
 
 ---
 
 ### 5. Technical Notes (The Cheat Sheet)
 
-Give the agent everything it needs to match your codebase patterns:
+Give the agent everything it needs to match your codebase:
 
 - **Key files** to read or modify
 - **Patterns to follow** (link to similar implementations)
-- **Dependencies** and imports
-- **Configuration** locations
+- **Dependencies** and configuration
 - **Testing approach**
 
 **Example:**
-
 ```
 Key files:
-- /plugins/prc-pdf-text-extraction/includes/rest-api/ (create here)
-- /plugins/prc-platform-core/includes/api/ (pattern reference)
+- src/api/routes/pipeline.ts (create here)
+- src/api/routes/health.ts (pattern reference)
 
 Patterns to follow:
-- REST endpoint registration via prc_api_endpoints filter
-- Response format matches existing PRC API v3 endpoints
-- Error handling follows class-api-error-handler.php
+- Route registration in src/api/index.ts
+- Error response format matches src/api/errors.ts
 
 Testing:
-- PHPUnit tests in /tests/rest-api/
-- Follow test-content-type.php structure
+- Jest tests in src/api/__tests__/
+- Follow health.test.ts structure
 ```
 
 ---
 
 ## The Agent-Ready Checklist
 
-Before labeling an issue `agent-ready`, verify:
+Before labeling an issue `agent-ready`:
 
 - [ ] **Scope is bounded** — Can be completed in one PR
 - [ ] **Success is measurable** — Clear pass/fail criteria
 - [ ] **Context is sufficient** — Agent can understand why without asking
 - [ ] **Patterns are referenced** — Links to similar code in the repo
 - [ ] **No external blockers** — API keys available, dependencies installed
-- [ ] **Complexity is labeled** — `low`, `medium`, or `high`
+- [ ] **Complexity is labeled** — `complexity:low`, `complexity:medium`, or `complexity:high`
 
 ---
 
 ## Complexity Levels
 
-### Low Complexity
-
+### `complexity:low`
 - Single file changes
 - Following an obvious existing pattern
 - Bug fixes with clear reproduction steps
 - Adding tests for existing code
 
-**Example:** Add validation for empty PDF attachments in the upload handler
+**Example:** Add validation for empty input in an existing form handler
 
-### Medium Complexity
-
+### `complexity:medium`
 - Multiple related files
 - New feature following established patterns
 - Refactoring with clear before/after states
 - Integration with one external system
 
-**Example:** Add REST endpoints for text extraction following existing API patterns
+**Example:** Add REST endpoints following existing API patterns in the codebase
 
-### High Complexity
-
+### `complexity:high`
 - Architectural decisions required
 - Multiple system integrations
 - New patterns being established
-- Performance-critical code
+- Performance-critical code paths
 
-**Example:** Design and implement multi-provider OCR orchestration with fallback logic
+**Example:** Design and implement a multi-provider data pipeline with fallback logic
 
-> **Note:** High complexity issues benefit from a planning phase before execution. Have the agent propose an implementation plan for human review before coding.
-
----
-
-## When Agents Excel
-
-✅ **Use agents for:**
-
-- Implementing features against clear specs
-- Following established patterns to new areas
-- Writing tests for existing code
-- Refactoring with defined outcomes
-- Bug fixes with clear reproduction steps
-- Documentation generation
-- Boilerplate and scaffolding
-
----
-
-## When Agents Struggle
-
-⚠️ **Be cautious with:**
-
-- Vague requirements ("make it better")
-- Novel architecture decisions
-- Performance optimization without metrics
-- Security-critical code (always human review)
-- Code requiring deep institutional knowledge
-- Tasks requiring external research
-
-> For these cases, use agents in **interactive mode** — work alongside them rather than delegating fully.
-
----
-
-## Anti-Patterns to Avoid
-
-### The Kitchen Sink Issue
-
-**Problem:** Issue tries to do too much
-**Symptom:** Multiple unrelated acceptance criteria
-**Fix:** Split into focused issues, link them with dependencies
-
-### The Assumption Issue
-
-**Problem:** Assumes agent knows your conventions
-**Symptom:** "Follow our standard approach"
-**Fix:** Link to specific examples, name the patterns
-
-### The Moving Target
-
-**Problem:** Requirements change during execution
-**Symptom:** Comments adding new requirements mid-PR
-**Fix:** New requirements = new issue. Keep original scope.
-
-### The Mystery Context
-
-**Problem:** No explanation of why
-**Symptom:** Agent makes wrong trade-offs
-**Fix:** Always include context section explaining purpose
-
-### The Perfectionist Trap
-
-**Problem:** Expecting production-perfect output
-**Symptom:** Frustration when agent code needs polish
-**Fix:** Expect 80-90%. Plan for human review and refinement.
+> **Note:** `complexity:high` issues trigger a planning phase when using Claude + CE. The agent generates an implementation plan that a human approves before any code is written.
 
 ---
 
@@ -236,15 +172,15 @@ Before labeling an issue `agent-ready`, verify:
 └─────────────────────────────────────────────────────────────┘
                               ↓
 ┌─────────────────────────────────────────────────────────────┐
-│  2. PLAN (Agent + Human)                                    │
+│  2. PLAN (Agent + Human)  — complexity:high only            │
 │     Agent proposes implementation plan                      │
-│     Human reviews and approves                              │
-│     (Skip for low complexity)                               │
+│     Human reviews: reply /approve-plan to proceed           │
+│     (Skipped for low/medium complexity)                     │
 └─────────────────────────────────────────────────────────────┘
                               ↓
 ┌─────────────────────────────────────────────────────────────┐
 │  3. EXECUTE (Agent)                                         │
-│     Agent implements against approved plan                  │
+│     Agent implements against issue (and plan if present)    │
 │     Creates PR with summary and testing notes               │
 └─────────────────────────────────────────────────────────────┘
                               ↓
@@ -258,119 +194,226 @@ Before labeling an issue `agent-ready`, verify:
 ┌─────────────────────────────────────────────────────────────┐
 │  5. FINALIZE (Human)                                        │
 │     Merge PR                                                │
-│     Deploy via standard process                             │
+│     Deploy via your standard process                        │
 │     Close issue                                             │
 └─────────────────────────────────────────────────────────────┘
 ```
 
 ---
 
-## Planning Phase Deep Dive
+## Compound Engineering Integration
 
-For medium and high complexity issues, the planning phase prevents wasted cycles.
+[Compound Engineering](https://github.com/anthropics/compound-engineering) is a Claude Code plugin that provides structured planning (`/ce-plan`) and work execution (`/ce-work`) skills.
 
-**What to ask for:**
+When `AGENT_PROVIDER=claude`, the trigger workflow uses CE automatically:
+
+### Low/Medium Complexity Flow
 
 ```
-Based on this issue, provide an implementation plan including:
-1. Files to create or modify
-2. Key functions/classes to implement
-3. How this integrates with existing code
-4. Potential risks or blockers
-5. Testing approach
-6. Estimated scope (small/medium/large PR)
+agent-ready label applied
+        ↓
+agent-ready-trigger.yml fires
+        ↓
+Claude invokes /ce-work on the issue
+        ↓
+/ce-work reads the issue, implements the feature, opens a PR
 ```
 
-**Review the plan for:**
+### High Complexity Flow
 
-- Correct understanding of requirements
-- Alignment with codebase patterns
-- Reasonable scope
-- Nothing obviously missing
+```
+agent-ready label applied
+        ↓
+agent-ready-trigger.yml fires
+        ↓
+Claude invokes /ce-plan on the issue
+        ↓
+Plan committed to docs/plans/ on a branch
+        ↓
+Claude posts comment: "Review plan → reply /approve-plan to implement"
+        ↓
+Human reviews the plan (in docs/plans/)
+        ↓
+Human replies /approve-plan
+        ↓
+plan-approval-gate.yml fires
+        ↓
+Claude invokes /ce-work with the plan as context
+        ↓
+/ce-work implements the plan and opens a PR
+```
 
-**Then:** Approve the plan or provide corrections before execution begins.
+### Using CE Interactively (Outside the Workflow)
+
+You can also invoke CE manually in your local Claude Code session:
+
+```bash
+# Plan a feature from an issue
+claude "/ce-plan [paste issue description or use issue URL]"
+
+# Execute a plan
+claude "/ce-work docs/plans/2026-01-15-001-feat-my-feature-plan.md"
+
+# Or work from the issue directly
+claude "/ce-work Implement the feature described in GitHub issue #42"
+```
+
+CE is a Claude Code plugin. Other providers use equivalent plain-language prompts without the CE skill layer — the workflow adapts the prompt accordingly.
 
 ---
 
-## Issue Template
+## GitHub Setup
 
-```markdown
-## Summary
+### Initial Setup (One Time)
 
-<!-- One sentence: what needs to happen -->
+1. **Use the template** — Click "Use this template" on GitHub
+2. **Enable the template flag** — Settings → General → check "Template repository"
+3. **Sync labels** — Actions → Setup Labels → Run workflow
+4. **Set your provider** — Settings → Secrets and variables → Variables → `AGENT_PROVIDER`
+5. **Add your secret** — Settings → Secrets and variables → Secrets → add the required token
 
-## Context
+### Labels
 
-<!-- Why this matters, who uses it, how it fits -->
+The workflow uses 7 labels. All are created by the Setup Labels workflow.
 
-## Acceptance Criteria
+| Label | Applied by | Meaning |
+|-------|-----------|---------|
+| `agent-ready` | Human or auto-labeler | Issue is scoped for agent execution |
+| `agent-candidate` | Issue screener | Screener flagged as promising — human review needed |
+| `agent-generated` | Agent | PR was created by an agent |
+| `needs-planning` | Human | Manual flag: this issue needs a plan before execution |
+| `complexity:low` | Human | Single file, clear pattern |
+| `complexity:medium` | Human | Multiple files, established patterns |
+| `complexity:high` | Human | Architectural work — triggers planning phase |
 
-- [ ] Criterion with measurable outcome
-- [ ] Another specific criterion
-- [ ] Tests pass
-- [ ] Code review approved
+### Adding CI Checks
 
-## Scope
+This template intentionally omits a CI workflow — linting and testing commands are too stack-specific to generalize. Add your own:
 
-**In scope:**
-
-- Specific deliverable 1
-- Specific deliverable 2
-
-**Out of scope:**
-
-- Explicitly excluded item
-- Future enhancement (separate issue)
-
-## Technical Notes
-
-**Key files:**
-
-- `/path/to/relevant/file.php`
-- `/path/to/pattern/reference.php`
-
-**Patterns to follow:**
-
-- Name the pattern, link to example
-
-**Dependencies:**
-
-- Required packages, API keys, etc.
-
-**Testing:**
-
-- How to verify this works
-
-## Complexity
-
-`complexity:medium`
-
-## Agent Readiness
-
-- [ ] Scope is bounded
-- [ ] Success is measurable
-- [ ] Context is sufficient
-- [ ] Patterns are referenced
-- [ ] No external blockers
+```yaml
+# .github/workflows/ci.yml
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install
+        run: npm install  # or: pip install, bundle install, etc.
+      - name: Lint
+        run: npm run lint
+      - name: Test
+        run: npm test
 ```
+
+### Code Review Guidelines for Agent PRs
+
+When reviewing agent-generated code, focus on:
+
+**1. Intent Match**
+- Does the code actually solve the issue?
+- Are acceptance criteria met?
+
+**2. Pattern Adherence**
+- Does it follow existing codebase patterns?
+- Are naming conventions consistent?
+
+**3. Edge Cases**
+- What happens with empty inputs?
+- Error handling present and correct?
+- Boundary conditions covered?
+
+**4. Security**
+- Input validation present?
+- No exposed secrets?
+- Data properly sanitized?
+
+**5. Tests**
+- Are tests actually testing behavior?
+- Edge cases covered?
+- Not just the happy path?
+
+---
+
+## When Agents Excel
+
+✅ **Use agents for:**
+- Implementing features against clear specs
+- Following established patterns to new areas
+- Writing tests for existing code
+- Refactoring with defined outcomes
+- Bug fixes with clear reproduction steps
+- Documentation generation
+- Boilerplate and scaffolding
+
+---
+
+## When Agents Struggle
+
+⚠️ **Be cautious with:**
+- Vague requirements ("make it better")
+- Novel architecture decisions
+- Performance optimization without metrics
+- Security-critical code (always human review)
+- Code requiring deep institutional knowledge
+
+> For these cases, use agents in **interactive mode** — work alongside them rather than delegating fully.
+
+---
+
+## Anti-Patterns to Avoid
+
+### The Kitchen Sink Issue
+**Problem:** Issue tries to do too much
+**Fix:** Split into focused issues, link them with dependencies
+
+### The Assumption Issue
+**Problem:** Assumes agent knows your conventions
+**Fix:** Link to specific examples, name the patterns explicitly
+
+### The Moving Target
+**Problem:** Requirements change during execution
+**Fix:** New requirements = new issue. Keep original scope.
+
+### The Mystery Context
+**Problem:** No explanation of why
+**Fix:** Always include context explaining purpose and users
+
+### The Perfectionist Trap
+**Problem:** Expecting production-perfect output
+**Fix:** Expect 80–90%. Plan for human review and refinement.
+
+---
+
+## Extending Provider Stubs
+
+The `openai-codex` and `copilot` jobs in `agent-ready-trigger.yml` are intentional stubs. To activate them:
+
+1. Open `.github/workflows/agent-ready-trigger.yml`
+2. Find the stub job for your provider (search for `# TODO: extend`)
+3. Replace the stub `run:` block with your actual invocation
+4. Add the required secret (see the job's `env:` block)
+
+If you build a working provider integration, consider contributing it back via a PR!
 
 ---
 
 ## Quick Reference
 
-| Element             | Question It Answers       |
-| ------------------- | ------------------------- |
-| Summary             | What are we building?     |
-| Context             | Why does it matter?       |
+| Element | Question It Answers |
+|---------|---------------------|
+| Summary | What are we building? |
+| Context | Why does it matter? |
 | Acceptance Criteria | How do we know it's done? |
-| Scope Boundaries    | What's in and out?        |
-| Technical Notes     | How do we build it?       |
+| Scope Boundaries | What's in and out? |
+| Technical Notes | How do we build it? |
 
 ---
 
 ## Getting Started
 
-1. **Start small** — Pick a low-complexity issue for your first agent-assisted task
+1. **Start small** — Pick a `complexity:low` issue for your first agent-assisted task
 2. **Use the template** — It forces good structure
 3. **Review agent output** — Learn what works and what needs refinement
 4. **Iterate on issues** — Improve your issue-writing based on results
@@ -378,228 +421,4 @@ Based on this issue, provide an implementation plan including:
 
 ---
 
-## GitHub Integration
-
-### Labels for Agent Workflow
-
-Set up these labels in your repository:
-
-| Label               | Purpose                                        |
-| ------------------- | ---------------------------------------------- |
-| `agent-ready`       | Issue is properly scoped for agent execution   |
-| `needs-planning`    | Requires agent planning phase before execution |
-| `agent-generated`   | PR was created by an agent                     |
-| `complexity:low`    | Single file, clear pattern                     |
-| `complexity:medium` | Multiple files, established patterns           |
-| `complexity:high`   | Architectural decisions, needs planning        |
-
-### Using Claude Code
-
-[Claude Code](https://claude.ai/claude-code) is the primary agent for this workflow. Issues labeled `agent-ready` automatically trigger Claude Code via the `agent-ready-trigger.yml` workflow. You can also run it manually:
-
-```bash
-# Navigate to repo
-cd ~/Sites/today
-
-# Have Claude read the issue and plan
-claude "Read issue #123 and create an implementation plan"
-
-# Review the plan, then execute
-claude "Implement the approved plan"
-
-# Claude creates commits on a branch — push and open a PR
-gh pr create --title "Implement feature X" --body "Closes #123"
-```
-
-**Tips for Claude Code:**
-
-- Well-structured issues with clear Technical Notes produce better results
-- Use the planning phase for medium/high complexity issues
-- The `agent-ready` label auto-triggers Claude via GitHub Actions
-- Claude will comment on the issue if it needs clarification
-
-### PR Template for Agent-Generated Code
-
-Create `.github/PULL_REQUEST_TEMPLATE/agent-generated.md`:
-
-```markdown
-## Agent-Generated PR
-
-**Issue:** #[issue_number]
-**Agent:** Claude Code
-**Complexity:** [low / medium / high]
-
-### Summary
-
-<!-- What this PR does -->
-
-### Implementation Notes
-
-<!-- Key decisions made, patterns followed -->
-
-### Testing Done
-
-- [ ] Automated tests pass
-- [ ] Manual testing performed
-- [ ] Edge cases considered
-
-### Review Checklist
-
-- [ ] Code follows project patterns
-- [ ] No security concerns
-- [ ] No hardcoded values that should be config
-- [ ] Tests are meaningful (not just coverage)
-- [ ] Documentation updated if needed
-
-### Human Reviewer Notes
-
-<!-- Anything the reviewer should pay special attention to -->
-```
-
-### CI Requirements for Agent PRs
-
-Configure required checks in branch protection:
-
-```yaml
-# .github/workflows/agent-pr-checks.yml
-name: Agent PR Validation
-
-on:
-    pull_request:
-        types: [opened, synchronize]
-
-jobs:
-    validate:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-
-            - name: Lint
-              run: npm run lint
-
-            - name: Type Check
-              run: npm run typecheck
-
-            - name: Unit Tests
-              run: npm test
-
-            - name: Security Scan
-              uses: github/codeql-action/analyze@v2
-```
-
-**Required checks before merge:**
-
-- All linting passes
-- All tests pass
-- Security scan clean
-- At least one human approval
-
-### Code Review Guidelines for Agent PRs
-
-When reviewing agent-generated code, focus on:
-
-**1. Intent Match**
-
-- Does the code actually solve the issue?
-- Are acceptance criteria met?
-
-**2. Pattern Adherence**
-
-- Does it follow existing codebase patterns?
-- Are naming conventions consistent?
-
-**3. Edge Cases**
-
-- What happens with empty inputs?
-- Error handling present?
-- Boundary conditions covered?
-
-**4. Security**
-
-- Input validation present?
-- No exposed secrets?
-- Proper escaping/sanitization?
-
-**5. Performance**
-
-- Any obvious N+1 queries?
-- Reasonable complexity?
-- Caching where appropriate?
-
-**6. Tests**
-
-- Are tests actually testing behavior?
-- Edge cases covered?
-- Not just happy path?
-
-### Automation Ideas
-
-**Auto-label agent-ready issues:**
-
-```yaml
-# .github/workflows/auto-label.yml
-name: Auto Label
-
-on:
-    issues:
-        types: [opened, edited]
-
-jobs:
-    label:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/github-script@v7
-              with:
-                  script: |
-                      const body = context.payload.issue.body || '';
-                      const hasAllSections =
-                        body.includes('## Summary') &&
-                        body.includes('## Acceptance Criteria') &&
-                        body.includes('## Scope') &&
-                        body.includes('## Technical Notes');
-
-                      if (hasAllSections) {
-                        await github.rest.issues.addLabels({
-                          owner: context.repo.owner,
-                          repo: context.repo.repo,
-                          issue_number: context.issue.number,
-                          labels: ['agent-ready']
-                        });
-                      }
-```
-
-**Notify on agent-ready:**
-
-```yaml
-# Post to Slack/Discord when issue is labeled agent-ready
-- name: Notify
-  if: contains(github.event.label.name, 'agent-ready')
-  run: |
-      curl -X POST $SLACK_WEBHOOK -d '{
-        "text": "Issue #${{ github.event.issue.number }} is ready for agent execution"
-      }'
-```
-
----
-
-## Resources
-
-**Agent Platforms:**
-
-- [Claude Code](https://claude.ai/claude-code) — Primary agent for this workflow
-- [Claude Code GitHub Action](https://github.com/anthropics/claude-code-action) — Automated agent triggering via GitHub Actions
-
-**Background Reading:**
-
-- [Cursor: Self-Driving Codebases](https://cursor.com/blog/self-driving-codebases) — Vision for agent-assisted development
-- [GitHub: AI-Powered Development](https://github.blog/ai-and-ml/) — GitHub's AI roadmap
-
-**This Repository:**
-
-- Issue Template: `/.github/ISSUE_TEMPLATE/agent-ready.md`
-- PR Template: `/.github/PULL_REQUEST_TEMPLATE/agent-generated.md`
-- Example Issues: See `agent-ready` label
-
----
-
-_This is a living document. Update it as you learn what works for your team and codebase._
+_This is a living document. Update it as you learn what works for your team._

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Adds the agentic workflow template to an existing repository.
+#
+# Usage (run from the root of your target repo):
+#   bash <(curl -fsSL https://raw.githubusercontent.com/whyisjake/agentic-workflow-template/main/scripts/setup.sh)
+#
+# Or clone and run locally:
+#   bash /path/to/agentic-workflow-template/scripts/setup.sh
+#
+# What this does:
+#   - Adds .github/ISSUE_TEMPLATE/agent-ready.md       (alongside existing templates)
+#   - Adds .github/PULL_REQUEST_TEMPLATE/agent-generated.md  (alongside existing templates)
+#   - Adds .github/LABELS.yml  (or prints merge instructions if one already exists)
+#   - Adds .github/workflows/  (all agent workflow files, skips any that already exist)
+#   - Adds .github/agents/issue-screener.agent.md
+#   - Creates docs/ if it doesn't exist
+#   - Prints next steps
+#
+# Nothing is committed — you review and commit the changes yourself.
+#
+# EXISTING TEMPLATES:
+#   Issue templates coexist — GitHub shows all files in ISSUE_TEMPLATE/ as choices.
+#   PR templates coexist   — GitHub shows all files in PULL_REQUEST_TEMPLATE/ as choices.
+#   If you use a single flat pull_request_template.md, this script adds a named
+#   PULL_REQUEST_TEMPLATE/ directory alongside it (both work at the same time).
+
+set -euo pipefail
+
+REPO_URL="https://raw.githubusercontent.com/whyisjake/agentic-workflow-template/main"
+TEMPLATE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." 2>/dev/null && pwd)" || true
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+green()  { printf '\033[0;32m%s\033[0m\n' "$*"; }
+yellow() { printf '\033[0;33m%s\033[0m\n' "$*"; }
+red()    { printf '\033[0;31m%s\033[0m\n' "$*"; }
+bold()   { printf '\033[1m%s\033[0m\n' "$*"; }
+dim()    { printf '\033[2m%s\033[0m\n' "$*"; }
+
+# Download a file from the template repo, or copy from a local clone
+fetch() {
+  local src="$1" dest="$2"
+  mkdir -p "$(dirname "$dest")"
+  if [[ -n "$TEMPLATE_DIR" && -f "$TEMPLATE_DIR/$src" ]]; then
+    cp "$TEMPLATE_DIR/$src" "$dest"
+  else
+    curl -fsSL "$REPO_URL/$src" -o "$dest"
+  fi
+}
+
+# ── Preflight ─────────────────────────────────────────────────────────────────
+
+if [[ ! -d ".git" ]]; then
+  red "Error: run this script from the root of a git repository."
+  exit 1
+fi
+
+bold ""
+bold "Agentic Workflow Template — Setup"
+echo  "Adding agent-ready workflow files to: $(basename "$(pwd)")"
+echo  ""
+
+# ── Issue template ────────────────────────────────────────────────────────────
+# GitHub shows every file in ISSUE_TEMPLATE/ as a separate choice when opening
+# an issue, so agent-ready.md coexists with bug_report.md, feature_request.md, etc.
+
+if [[ -d ".github/ISSUE_TEMPLATE" ]]; then
+  dim "  .github/ISSUE_TEMPLATE/ already exists — adding agent-ready.md alongside your existing templates"
+fi
+
+if [[ -f ".github/ISSUE_TEMPLATE/agent-ready.md" ]]; then
+  yellow "  skipped (already exists): .github/ISSUE_TEMPLATE/agent-ready.md"
+else
+  fetch ".github/ISSUE_TEMPLATE/agent-ready.md" ".github/ISSUE_TEMPLATE/agent-ready.md"
+  green "  added: .github/ISSUE_TEMPLATE/agent-ready.md"
+fi
+
+# ── PR template ───────────────────────────────────────────────────────────────
+# GitHub supports multiple named PR templates in PULL_REQUEST_TEMPLATE/.
+# If you have a flat .github/pull_request_template.md, both approaches work
+# simultaneously — GitHub uses the named directory when it exists.
+
+if [[ -f ".github/pull_request_template.md" ]]; then
+  dim "  Found .github/pull_request_template.md — adding named PULL_REQUEST_TEMPLATE/ alongside it"
+  dim "  (GitHub uses named templates when PULL_REQUEST_TEMPLATE/ exists; your existing template is unaffected)"
+fi
+
+if [[ -f ".github/PULL_REQUEST_TEMPLATE/agent-generated.md" ]]; then
+  yellow "  skipped (already exists): .github/PULL_REQUEST_TEMPLATE/agent-generated.md"
+else
+  fetch ".github/PULL_REQUEST_TEMPLATE/agent-generated.md" ".github/PULL_REQUEST_TEMPLATE/agent-generated.md"
+  green "  added: .github/PULL_REQUEST_TEMPLATE/agent-generated.md"
+fi
+
+# ── LABELS.yml ────────────────────────────────────────────────────────────────
+
+if [[ -f ".github/LABELS.yml" ]]; then
+  yellow "  skipped (already exists): .github/LABELS.yml"
+  echo   "  → To add agent labels, append these entries to your existing LABELS.yml:"
+  echo   "    $REPO_URL/.github/LABELS.yml"
+else
+  fetch ".github/LABELS.yml" ".github/LABELS.yml"
+  green "  added: .github/LABELS.yml"
+fi
+
+# ── Workflows ────────────────────────────────────────────────────────────────
+# Each workflow file is independent — skipping an existing file leaves the
+# rest unaffected.
+
+WORKFLOW_FILES=(
+  ".github/workflows/agent-ready-trigger.yml"
+  ".github/workflows/plan-approval-gate.yml"
+  ".github/workflows/setup-labels.yml"
+  ".github/workflows/auto-label-agent-ready.yml"
+  ".github/workflows/issue-screener.yml"
+)
+
+for file in "${WORKFLOW_FILES[@]}"; do
+  if [[ -f "$file" ]]; then
+    yellow "  skipped (already exists): $file"
+  else
+    fetch "$file" "$file"
+    green "  added: $file"
+  fi
+done
+
+# ── Agent file ────────────────────────────────────────────────────────────────
+
+if [[ -f ".github/agents/issue-screener.agent.md" ]]; then
+  yellow "  skipped (already exists): .github/agents/issue-screener.agent.md"
+else
+  fetch ".github/agents/issue-screener.agent.md" ".github/agents/issue-screener.agent.md"
+  green "  added: .github/agents/issue-screener.agent.md"
+fi
+
+# ── docs/ directory ───────────────────────────────────────────────────────────
+
+if [[ ! -d "docs" ]]; then
+  mkdir -p docs
+  green "  created: docs/"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+bold "Done. Next steps:"
+echo ""
+echo "  1. Review added files:"
+echo "     git status"
+echo ""
+echo "  2. Commit:"
+echo "     git add .github/ docs/"
+echo "     git commit -m 'chore: add agentic workflow template'"
+echo "     git push"
+echo ""
+echo "  3. Sync labels (run once after pushing):"
+echo "     Actions → Setup Labels → Run workflow"
+echo ""
+echo "  4. Configure your agent (optional, defaults to claude):"
+echo "     Settings → Secrets and variables → Variables → AGENT_PROVIDER"
+echo "     Settings → Secrets and variables → Secrets → CLAUDE_CODE_OAUTH_TOKEN"
+echo ""
+echo "  Full docs: https://github.com/whyisjake/agentic-workflow-template"
+echo ""


### PR DESCRIPTION
## Summary

- Upgrades `agent-ready-trigger.yml` to the multi-provider, complexity-aware version from the template — supports Claude (default), OpenAI Codex, GitHub Copilot, and custom via `AGENT_PROVIDER` variable
- Adds missing workflows that were installed locally but never committed: `issue-screener.yml`, `plan-approval-gate.yml`, `setup-labels.yml`
- Adds `.github/agents/issue-screener.agent.md` (Claude-powered issue screener agent)
- Updates `docs/AGENTIC_DEVELOPMENT.md` to template v1.0 (June 2026) with Provider Overview table and Compound Engineering integration guide
- Adds `scripts/setup.sh` for installing the template on other repos
- Generalizes `agent-ready.md` issue template (removes PRC-specific file path references)

## Key workflow change

`agent-ready-trigger.yml` now routes by complexity:
- `complexity:high` → runs `/ce-plan`, commits plan to `docs/plans/`, waits for human `/approve-plan` comment
- `complexity:low` / `complexity:medium` (or no label) → runs `/ce-work` directly

## Test plan

- [ ] Verify Setup Labels workflow runs successfully: Actions → Setup Labels → Run workflow
- [ ] Open a test issue with the `agent-ready` template and confirm auto-labeler fires
- [ ] Apply `agent-ready` label to a `complexity:low` issue and confirm `agent-ready-trigger.yml` runs `/ce-work`

🤖 Generated with [Claude Code](https://claude.com/claude-code)