### PR TITLE
fix: CI agent permissions and workflow prompts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,29 @@
+{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Write",
+      "Edit",
+      "Glob",
+      "Grep",
+      "Bash(git *)",
+      "Bash(gh *)",
+      "Bash(find *)",
+      "Bash(ls *)",
+      "Bash(cat *)",
+      "Bash(grep *)",
+      "Bash(chmod *)",
+      "Bash(mkdir *)",
+      "Bash(cp *)",
+      "Bash(mv *)",
+      "Bash(sed *)",
+      "Bash(wc *)",
+      "Bash(sort *)",
+      "Bash(head *)",
+      "Bash(tail *)",
+      "Bash(echo *)",
+      "Bash(curl *)"
+    ],
+    "deny": []
+  }
+}

--- a/.github/workflows/agent-ready-trigger.yml
+++ b/.github/workflows/agent-ready-trigger.yml
@@ -75,21 +75,23 @@ jobs:
             This is a complexity:high issue. Your job is to PLAN, not implement.
 
             Instructions:
-            1. Read the full issue body carefully
-            2. Invoke /ce-plan with the issue description as input to generate a structured
-               implementation plan
-            3. Commit the generated plan file to docs/plans/ on a new branch named
+            1. Read the full issue body:
+               gh issue view ${{ github.event.issue.number }} --repo ${{ github.repository }}
+            2. Read CLAUDE.md for project-specific guidance
+            3. Read the key files referenced in Technical Notes to understand the codebase
+            4. Write a structured implementation plan as a markdown file saved to:
+               docs/plans/YYYY-MM-DD-NNN-<type>-<short-title>-plan.md
+               The plan should include: problem frame, requirements, scope boundaries,
+               key technical decisions, and implementation units (each with goal, files,
+               approach, and test scenarios)
+            5. Commit the plan file to a new branch named:
                plan/issue-${{ github.event.issue.number }}
-            4. After committing, post a comment on the issue with:
-               - A link to the plan file (use the GitHub file URL)
-               - The message: "Implementation plan is ready for review. Reply /approve-plan
-                 to begin implementation, or comment with feedback to revise the plan."
-            5. Do NOT write any application code
-            6. Do NOT open a pull request
-
-            After posting the comment, verify that a plan file was committed to docs/plans/.
-            If /ce-plan was unavailable or the commit failed, post a comment explaining what
-            happened instead of the approval-request message.
+            6. After committing, post a comment on the issue with:
+               - A link to the plan file (GitHub URL)
+               - "Implementation plan is ready for review. Reply /approve-plan to begin
+                 implementation, or comment with feedback to revise the plan."
+            7. Do NOT write any application code
+            8. Do NOT open a pull request
 
       # ── LOW/MEDIUM COMPLEXITY: execute directly ──────────────────────────────
       - name: Run Claude Code — Direct Execution (complexity:low/medium)
@@ -106,13 +108,18 @@ jobs:
             Issue title: ${{ github.event.issue.title }}
 
             Instructions:
-            1. Read the full issue body carefully
-            2. Invoke /ce-work with the issue as input to implement the feature
-            3. Stay within the defined scope — "Out of scope" is a hard boundary
-            4. Follow the patterns referenced in Technical Notes
-            5. Open a PR using the agent-generated PR template
-            6. Add the 'agent-generated' label to the PR
-            7. Reference the issue in the PR body: "Closes #${{ github.event.issue.number }}"
+            1. Read the full issue body carefully using the GitHub CLI:
+               gh issue view ${{ github.event.issue.number }} --repo ${{ github.repository }}
+            2. Read CLAUDE.md for project-specific guidance
+            3. Implement the feature following the acceptance criteria exactly
+            4. Stay within the defined scope — "Out of scope" is a hard boundary
+            5. Follow the patterns referenced in Technical Notes (read the key files listed there)
+            6. Create a branch, commit your changes, and open a PR:
+               - Branch name: agent/issue-${{ github.event.issue.number }}
+               - PR title should match the issue title
+               - PR body: reference "Closes #${{ github.event.issue.number }}" and summarize what you did
+               - Use the template at .github/PULL_REQUEST_TEMPLATE/agent-generated.md if it exists
+            7. Add the 'agent-generated' label to the PR
 
             If you are blocked or unclear on something, post a comment on the issue
             asking for clarification rather than guessing.

--- a/docs/plans/2026-06-15-002-fix-reddit-gallery-fullscreen-ipad-plan.md
+++ b/docs/plans/2026-06-15-002-fix-reddit-gallery-fullscreen-ipad-plan.md
@@ -1,0 +1,111 @@
+---
+title: "fix: Open Reddit gallery images full screen on iPad"
+type: fix
+status: active
+date: 2026-06-15
+---
+
+# fix: Open Reddit gallery images full screen on iPad
+
+## Summary
+
+On iPad, tapping a Reddit gallery image opens `FullScreenImageGallery` as a `.sheet`, which renders as a card-style modal rather than occupying the full display. Changing the iOS presentation to `.fullScreenCover` makes the gallery cover the entire screen, matching expected full-screen image viewer behavior.
+
+---
+
+## Problem Frame
+
+On iPad, `.sheet` presentations appear as a floating card over the content behind it. For an image gallery, this wastes screen real estate and breaks the immersive feel. `.fullScreenCover` covers the entire display, which is the appropriate treatment for a full-screen image viewer.
+
+---
+
+## Requirements
+
+- R1. Tapping a Reddit gallery image on iPad (and iPhone) opens the gallery covering the full screen.
+- R2. The existing "Done" button and all gallery functionality (zoom, pan, swipe, share) remain intact.
+- R3. The black background and navigation bar continue to render correctly.
+
+---
+
+## Scope Boundaries
+
+- macOS gallery sheet presentation is not changed.
+- No changes to `FullScreenImageGallery` view internals.
+- No changes to zoom, pan, video playback, or share behavior.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `Today/Views/RedditPostView.swift` lines 986–991 — the iOS `.sheet` modifier on `ImageGalleryView`
+- `FullScreenImageGallery` already has `@Environment(\.dismiss)` and a "Done" toolbar button — dismissal works correctly with both `.sheet` and `.fullScreenCover`
+- `.presentationDragIndicator(.visible)` and `.presentationBackground(.black)` are sheet-specific modifiers and must be removed; `FullScreenImageGallery` already applies `platformBackgroundColor` (black) to its own background
+
+### Key Observations
+
+- `FullScreenImageGallery` uses `.ignoresSafeArea()` — already prepared for edge-to-edge display
+- The view is wrapped in a `NavigationStack` with a visible toolbar, so status bar overlap is handled correctly under `.fullScreenCover`
+- Swipe-to-dismiss is not available with `.fullScreenCover` by default; the "Done" button is the primary dismiss path, which is already in place
+
+---
+
+## Key Technical Decisions
+
+- **`.fullScreenCover` over `.sheet`**: Covers the entire screen on all iOS/iPadOS devices. No additional configuration needed — the existing view is already built for full-screen display.
+- **Remove sheet-specific modifiers**: `.presentationDragIndicator(.visible)` and `.presentationBackground(.black)` are no-ops on `.fullScreenCover` and produce a compiler warning; removing them is correct.
+- **No swipe-to-dismiss**: `.fullScreenCover` does not support the pull-down swipe-to-dismiss gesture that `.sheet` provides. The "Done" button is sufficient and already implemented.
+
+---
+
+## Implementation Units
+
+### U1. Replace `.sheet` with `.fullScreenCover` for iOS gallery presentation
+
+**Goal:** Make the Reddit gallery open full screen on iOS/iPadOS instead of as a modal card.
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `Today/Views/RedditPostView.swift`
+
+**Approach:**
+- In the `#if os(iOS)` block of `ImageGalleryView` (around line 987), replace `.sheet(isPresented: $showFullScreen)` with `.fullScreenCover(isPresented: $showFullScreen)`
+- Remove the `.presentationDragIndicator(.visible)` and `.presentationBackground(.black)` modifiers from the presented view — they are sheet-only APIs and do not apply to `fullScreenCover`
+- No changes inside `FullScreenImageGallery` itself
+
+**Patterns to follow:**
+- The existing macOS path uses `.sheet` with explicit sizing — leave it untouched
+- `FullScreenImageGallery` already handles its own background and dismiss button
+
+**Test scenarios:**
+- Happy path: Tap any image in a Reddit gallery on an iPad simulator → gallery opens covering the full screen with no visible content behind it
+- Happy path: Tap "Done" button → gallery dismisses and article content returns
+- Happy path: On iPhone → gallery also opens full screen (behavior improved there too)
+- Edge case: Gallery with a single image → opens full screen, "1 of 1" title shows correctly
+- Edge case: Gallery with animated GIF/video → video plays correctly in full-screen cover
+- Regression: macOS gallery sheet behavior unchanged
+
+**Verification:**
+- On iPad simulator, tapping a gallery image shows `FullScreenImageGallery` edge-to-edge with no card shadow or sheet drag indicator
+- "Done" button dismisses correctly
+- Zoom, pan, swipe between images, and share sheet all function as before
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Loss of swipe-to-dismiss | "Done" button already present and functional; acceptable trade-off for full-screen UX |
+| Sheet-specific modifiers causing warnings if not removed | Remove both modifiers as part of this change |
+
+---
+
+## Sources & References
+
+- Implementation file: `Today/Views/RedditPostView.swift` (lines 986–1011)
+- Gallery view: `FullScreenImageGallery` struct (lines 1017–)


### PR DESCRIPTION
## Summary

The first agent run (issue #100) produced 48 permission denials and no PR. This PR fixes both root causes.

## Root causes

1. **No `.claude/settings.json`** — Claude Code in CI can't interactively approve tool use. Without a committed settings file pre-allowing tools, every `Read`, `Write`, `Edit`, and `Bash` call was silently denied.

2. **`/ce-work` and `/ce-plan` in workflow prompts** — These are Compound Engineering plugin slash commands that only work in a local Claude Code session where the plugin is installed. The CI agent environment has no plugins, so the agent spent the entire run trying to invoke a command that doesn't exist.

## Changes

- **`.claude/settings.json`** — Grants `Read`, `Write`, `Edit`, `Glob`, `Grep`, and a standard set of `Bash` commands (`git`, `gh`, `find`, `ls`, `cat`, `grep`, `curl`, etc.) so the agent can implement issues without permission prompts
- **`agent-ready-trigger.yml` low/medium prompt** — Replaced `/ce-work` instruction with direct implementation steps using `gh issue view` and standard git/gh workflow
- **`agent-ready-trigger.yml` high-complexity prompt** — Replaced `/ce-plan` instruction with direct plan-writing steps (the same plan format, just without the plugin)
- **`docs/plans/`** — Plan file for issue #100 committed here

## Test plan

- [ ] Re-trigger the agent on issue #100 by removing and re-adding the `agent-ready` label — expect a PR to be created with no permission denials
- [ ] Verify `complexity:high` flow: label a high-complexity issue `agent-ready` and confirm a plan file is committed to `docs/plans/`

Closes relates to issue #100 (the fix itself will land via the agent run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)